### PR TITLE
IM-04: NHDD mapping prototype

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,6 +40,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>${opencsv.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/org/openmrs/module/interop/NhddMapping/CsvUtil/CsvParser.java
+++ b/api/src/main/java/org/openmrs/module/interop/NhddMapping/CsvUtil/CsvParser.java
@@ -1,0 +1,34 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.interop.NhddMapping.CsvUtil;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.List;
+
+import com.opencsv.bean.CsvToBeanBuilder;
+
+public class CsvParser {
+	
+	private File fileName;
+	
+	public CsvParser(File fileName) {
+		this.fileName = fileName;
+	}
+	
+	public List<NHDDConceptMapDTO> getConcepts() throws FileNotFoundException {
+		List<NHDDConceptMapDTO> concepts = new CsvToBeanBuilder<NHDDConceptMapDTO>(new FileReader(fileName))
+		        .withType(NHDDConceptMapDTO.class).build().parse();
+		
+		return concepts;
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/interop/NhddMapping/CsvUtil/NHDDConceptMapDTO.java
+++ b/api/src/main/java/org/openmrs/module/interop/NhddMapping/CsvUtil/NHDDConceptMapDTO.java
@@ -1,0 +1,36 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.interop.NhddMapping.CsvUtil;
+
+import com.opencsv.bean.CsvBindByName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NHDDConceptMapDTO {
+	
+	@CsvBindByName(column = "CIELId")
+	private String CIELId;
+	
+	@CsvBindByName(column = "CIELDatatype")
+	private String CIELDatatype;
+	
+	@CsvBindByName(column = "NhddId")
+	private String NhddId;
+	
+	@CsvBindByName(column = "NhddDatatype")
+	private String NhddDatatype;
+	
+}

--- a/api/src/main/java/org/openmrs/module/interop/NhddMapping/translations/InteropConceptTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/interop/NhddMapping/translations/InteropConceptTranslatorImpl.java
@@ -1,0 +1,96 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.interop.NhddMapping.translations;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.openmrs.Concept;
+import org.openmrs.module.fhir2.api.translators.impl.ConceptTranslatorImpl;
+import org.openmrs.module.interop.NhddMapping.CsvUtil.CsvParser;
+import org.openmrs.module.interop.NhddMapping.CsvUtil.NHDDConceptMapDTO;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Primary
+@Component
+public class InteropConceptTranslatorImpl extends ConceptTranslatorImpl {
+	
+	List<NHDDConceptMapDTO> concepts = new ArrayList<>();
+	
+	@Override
+	public CodeableConcept toFhirResource(@Nonnull Concept concept) {
+		CodeableConcept codeableConcept = super.toFhirResource(concept);
+		if (codeableConcept == null) {
+			return null;
+		}
+		initConcepts();
+		
+		if (!codeableConcept.getCoding().isEmpty()) {
+			List<Coding> cielCode = codeableConcept.getCoding().stream().filter(ci -> {
+				if (ci.getSystem() != null) {
+					return ci.getSystem().equals("https://openconceptlab.org/orgs/CIEL/sources/CIEL");
+				}
+				return false;
+			}).collect(Collectors.toList());
+			if (!cielCode.isEmpty()) {
+				concepts = concepts.stream().filter((i) -> i.getCIELId().equals(cielCode.get(0).getCode()))
+				        .collect(Collectors.toList());
+				if (!concepts.isEmpty()) {
+					NHDDConceptMapDTO c = concepts.get(0);
+					codeableConcept.setCoding(new ArrayList<>());
+					Coding coding = new Coding();
+					coding.setCode(c.getNhddId());
+					coding.setDisplay(cielCode.get(0).getDisplay());
+					coding.setSystem("https://nhdd.health.go.ke/");
+					codeableConcept.getCoding().add(coding);
+				}
+				
+			}
+		}
+		return codeableConcept;
+	}
+	
+	@Override
+	public Concept toOpenmrsType(@Nonnull CodeableConcept concept) {
+		return super.toOpenmrsType(concept);
+	}
+	
+	private void initConcepts() {
+		try {
+			URL resource = this.getClass().getClassLoader().getResource("metadata/NHDDConceptMapping.csv");
+			File file = Paths.get(resource.toURI()).toFile();
+			
+			CsvParser parser = new CsvParser(file);
+			
+			try {
+				concepts = parser.getConcepts();
+			}
+			catch (FileNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/api/src/main/resources/metadata/NHDDConceptMapping.csv
+++ b/api/src/main/resources/metadata/NHDDConceptMapping.csv
@@ -1,0 +1,3 @@
+CIELId,CIELDatatype,NhddId,NhddDatatype
+1054,Text,49315,Text
+1086,Text,9000,Text

--- a/pom.xml
+++ b/pom.xml
@@ -212,5 +212,6 @@
         <hapifhirVersion>4.2.0</hapifhirVersion>
         <openmrsPlatformVersion>2.3.4</openmrsPlatformVersion>
         <openmrsPlatformToolsVersion>2.4.0</openmrsPlatformToolsVersion>
+        <opencsv.version>5.7.0</opencsv.version>
     </properties>
 </project>


### PR DESCRIPTION
This PR is a proof of concept. Am extending fhir2 class ConceptTranslatorImpl that translates Concept in OpenMRS to a CodeableConcept in fhir. I have extended the class with InteropConceptTranslatorImpl which is marked as the primary bean and will be loaded instead of ConceptTranslatorImpl.

I am using csv as the mapping file.

Here is an exmple of a code with ciel code 1054 in the initial implementation with ConceptTranslatorImpl

        "coding": [
            {
                "code": "1054AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                "display": "Civil status"
            },
            {
                "system": "https://openconceptlab.org/orgs/CIEL/sources/CIEL",
                "code": "1054",
                "display": "Civil status"
            },
            {
                "system": "http://snomed.info/sct",
                "code": "365581002",
                "display": "Civil status"
            }
        ],
        "text": "Civil status"
    }
Here is the equivaent code after nhdd mapping done here ConceptTranslatorImpl

        "coding": [
            {
                "system": "https://nhdd.health.go.ke/",
                "code": "49315",
                "display": "Civil status"
            }
        ],
        "text": "Civil status"
    }
(Here am only generating the NHDD code but we can decide whether to also retain CIEL code)